### PR TITLE
Set default style

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An ANSI color-code highlighting lexer for Pygments.
 
    For example, let's choose `pygments.styles.xcode.XcodeStyle`, which looks
    great to use. And then we will augment this reference style with
-   `pygments-ansi-color`'s color tokens thank to the `color_tokens` function,
+   `pygments-ansi-color`'s color tokens thanks to the `color_tokens` function,
    to make our final `MyStyle` custom style.
 
    Here is how the code looks like:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 pygments-ansi-color
---------
+-------------------
 
 [![Build Status](https://travis-ci.org/chriskuehl/pygments-ansi-color.svg?branch=master)](https://travis-ci.org/chriskuehl/pygments-ansi-color)
 [![Coverage Status](https://coveralls.io/repos/github/chriskuehl/pygments-ansi-color/badge.svg?branch=master)](https://coveralls.io/github/chriskuehl/pygments-ansi-color?branch=master)
@@ -10,49 +10,37 @@ An ANSI color-code highlighting lexer for Pygments.
 ![](https://i.fluffy.cc/nHPkL3gfBtj5Kt4H3RR51T9TJLh6rtv2.png)
 
 
-### Usage
+### Basic usage
 
-1. `pip install pygments-ansi-color`
+1. Install `pygments-ansi-color`:
 
-2. Configure your Pygments style with the appropriate color tokens. It's
-   necessary to add additional tokens because existing Pygments lexers are
-   built around contextual tokens (think "Comment" or "String") rather than
-   actual colors.
+   ```shell-session
+   $ pip install pygments-ansi-color
+   ```
 
-   In the case of ANSI escape sequences, colors have no context beyond the
-   color themselves; we'd always want a "red" rendered as "red", regardless of
-   your particular theme.
+2. `pygments-ansi-color` is not magic (yet?), so you need to [choose an exising
+   Pygments style](https://pygments.org/styles/), which will be used as a base
+   for your own style.
 
-   Here's an example:
+   For example, let's choose `pygments.styles.xcode.XcodeStyle`, which looks
+   great to use. And then we will augment this reference style with
+   `pygments-ansi-color`'s color tokens thank to the `color_tokens` function,
+   to make our final `MyStyle` custom style.
+
+   Here is how the code looks like:
 
    ```python
    from pygments_ansi_color import color_tokens
 
-   # Note: You can use different background colors for improved readability.
-   fg_colors = bg_colors = {
-       'Black': '#000000',
-       'Red': '#EF2929',
-       'Green': '#8AE234',
-       'Yellow': '#FCE94F',
-       'Blue': '#3465A4',
-       'Magenta': '#c509c5',
-       'Cyan': '#34E2E2',
-       'White': '#F5F5F5',
-       'BrightBlack': '#676767',
-       'BrightRed': '#FF6D67',
-       'BrightGreen': '#5FF967',
-       'BrightYellow': '#FEFB67',
-       'BrightBlue': '#6871FF',
-       'BrightMagenta': '#FF76FF',
-       'BrightCyan': '#5FFDFF',
-       'BrightWhite': '#FEFFFF',
-   }
    class MyStyle(pygments.styles.xcode.XcodeStyle):
        styles = dict(pygments.styles.xcode.XcodeStyle.styles)
-       styles.update(color_tokens(fg_colors, bg_colors))
+       styles.update(color_tokens())
    ```
 
-3. Render your code!
+   That's all the custom code you need to integrate with `pygments-ansi-color`.
+
+3. Now you can highlight your content with the dedicated ANSI lexer and your
+   custom style, with the Pygments regular API:
 
    ```python
    import pygments
@@ -64,8 +52,62 @@ An ANSI color-code highlighting lexer for Pygments.
    print(pygments.highlight('your text', lexer, formatter))
    ```
 
+### Design
 
-### Example
+We had to configure above a custom Pygments style with the appropriate color
+tokens. That's because existing Pygments lexers are built around contextual
+tokens (think `Comment` or `Punctuation`) rather than actual colors.
+
+In the case of ANSI escape sequences, colors have no context beyond the color
+themselves; we'd always want a `red` rendered as `red`, regardless of your
+particular theme.
+
+
+### Custom theme
+
+By default, `pygments-ansi-color` maps ANSI codes to its own set of colors.
+They have been carefully crafted for readability, and are [loosely based on the
+color scheme used by iTerm2
+](https://github.com/chriskuehl/pygments-ansi-color/pull/27#discussion_r1113790011).
+
+Default colors are hard-coded by the `pygments_ansi_color.DEFAULT_STYLE`
+constant as such:
+- `Black`: `#000000`
+- `Red`: `#ef2929`
+- `Green`: `#8ae234`
+- `Yellow`: `#fce94f`
+- `Blue`: `#3465a4`
+- `Magenta`: `#c509c5`
+- `Cyan`: `#34e2e2`
+- `White`: `#f5f5f5`
+- `BrightBlack`: `#676767`
+- `BrightRed`: `#ff6d67`
+- `BrightGreen`: `#5ff967`
+- `BrightYellow`: `#fefb67`
+- `BrightBlue`: `#6871ff`
+- `BrightMagenta`: `#ff76ff`
+- `BrightCyan`: `#5ffdff`
+- `BrightWhite`: `#feffff`
+
+Still, you may want to use your own colors, to tweak the rendering to your
+background color, or to match your own theme.
+
+For that you can override each color individually, by passing them as
+arguments to the `color_tokens` function:
+
+```python
+from pygments_ansi_color import color_tokens
+
+class MyStyle(pygments.styles.xcode.XcodeStyle):
+   styles = dict(pygments.styles.xcode.XcodeStyle.styles)
+   styles.update(color_tokens(
+      fg_colors={'Cyan': '#00ffff', 'BrightCyan': '#00ffff'},
+      bg_colors={'BrightWhite': '#000000'},
+   ))
+```
+
+
+### Used by
 
 You can see an example [on fluffy][fluffy-example], the project that this lexer
 was originally developed for.
@@ -101,7 +143,7 @@ If you'd like to enable 256-color support, you'll need to do two things:
 1. When calling `color_tokens`, pass `enable_256color=True`:
 
    ```python
-   styles.update(color_tokens(fg_colors, bg_colors, enable_256color=True))
+   styles.update(color_tokens(enable_256color=True))
    ```
 
    This change is what causes your CSS to have the appropriate classes in it.

--- a/pygments_ansi_color/__init__.py
+++ b/pygments_ansi_color/__init__.py
@@ -152,12 +152,12 @@ def color_tokens(
     styles: dict[pygments.token._TokenType, str] = {}
 
     # Validates custom color IDs.
-    if not set(fg_colors).issubset(DEFAULT_STYLE):
+    if not set(fg_colors).issubset(DEFAULT_STYLE):  # pragma: no cover (trivial)
         raise ValueError(
             f'Unrecognized {set(fg_colors).difference(DEFAULT_STYLE)}'
             ' foreground color',
         )
-    if not set(bg_colors).issubset(DEFAULT_STYLE):
+    if not set(bg_colors).issubset(DEFAULT_STYLE):  # pragma: no cover (trivial)
         raise ValueError(
             f'Unrecognized {set(bg_colors).difference(DEFAULT_STYLE)}'
             ' background color',

--- a/pygments_ansi_color/__init__.py
+++ b/pygments_ansi_color/__init__.py
@@ -95,9 +95,29 @@ def _token_from_lexer_state(
         return token
 
 
+DEFAULT_STYLE = {
+    'Black': '#000000',
+    'Red': '#ef2929',
+    'Green': '#8ae234',
+    'Yellow': '#fce94f',
+    'Blue': '#3465a4',
+    'Magenta': '#c509c5',
+    'Cyan': '#34e2e2',
+    'White': '#f5f5f5',
+    'BrightBlack': '#676767',
+    'BrightRed': '#ff6d67',
+    'BrightGreen': '#5ff967',
+    'BrightYellow': '#fefb67',
+    'BrightBlue': '#6871ff',
+    'BrightMagenta': '#ff76ff',
+    'BrightCyan': '#5ffdff',
+    'BrightWhite': '#feffff',
+}
+
+
 def color_tokens(
-    fg_colors: dict[str, str],
-    bg_colors: dict[str, str],
+    fg_colors: dict[str, str] = DEFAULT_STYLE,
+    bg_colors: dict[str, str] = DEFAULT_STYLE,
     enable_256color: bool = False,
 ) -> dict[pygments.token._TokenType, str]:
     """Return color tokens for a given set of colors.
@@ -122,29 +142,30 @@ def color_tokens(
 
     Usage:
 
-        fg_colors = bg_colors = {
-            'Black': '#000000',
-            'Red': '#EF2929',
-            'Green': '#8AE234',
-            'Yellow': '#FCE94F',
-            'Blue': '#3465A4',
-            'Magenta': '#c509c5',
-            'Cyan': '#34E2E2',
-            'White': '#F5F5F5',
-            'BrightBlack': '#676767',
-            'BrightRed': '#FF6D67',
-            'BrightGreen': '#5FF967',
-            'BrightYellow': '#FEFB67',
-            'BrightBlue': '#6871FF',
-            'BrightMagenta': '#FF76FF',
-            'BrightCyan': '#5FFDFF',
-            'BrightWhite': '#FEFFFF',
-        }
-        class MyStyle(pygments.styles.SomeStyle):
-            styles = dict(pygments.styles.SomeStyle.styles)
-            styles.update(color_tokens(fg_colors, bg_colors))
+        .. code-block:: python
+            from pygments_ansi_color import color_tokens
+
+            class MyStyle(pygments.styles.SomeStyle):
+                styles = dict(pygments.styles.SomeStyle.styles)
+                styles.update(color_tokens())
     """
     styles: dict[pygments.token._TokenType, str] = {}
+
+    # Validates custom color IDs.
+    if not set(fg_colors).issubset(DEFAULT_STYLE):
+        raise ValueError(
+            f'Unrecognized {set(fg_colors).difference(DEFAULT_STYLE)}'
+            ' foreground color',
+        )
+    if not set(bg_colors).issubset(DEFAULT_STYLE):
+        raise ValueError(
+            f'Unrecognized {set(bg_colors).difference(DEFAULT_STYLE)}'
+            ' background color',
+        )
+
+    # Merge the default colors with the user-provided colors.
+    fg_colors = {**DEFAULT_STYLE, **fg_colors}
+    bg_colors = {**DEFAULT_STYLE, **bg_colors}
 
     if enable_256color:
         styles[pygments.token.Token.C.Bold] = 'bold'

--- a/tests/pygments_ansi_color_test.py
+++ b/tests/pygments_ansi_color_test.py
@@ -27,10 +27,24 @@ def test_token_from_lexer_state(bold, faint, fg_color, bg_color, expected):
     assert ret == expected
 
 
-def test_color_tokens():
+@pytest.fixture
+def default_color_tokens():
+    return dict(
+        itertools.chain.from_iterable(
+            (
+                (getattr(C, name), value),
+                (getattr(C, f'BG{name}'), f'bg:{value}'),
+            )
+            for name, value in main.DEFAULT_STYLE.items()
+        ),
+    )
+
+
+def test_color_tokens(default_color_tokens):
     fg_colors = {'Red': '#ff0000'}
     bg_colors = {'Green': '#00ff00'}
-    assert main.color_tokens(fg_colors, bg_colors) == {
+    ret = main.color_tokens(fg_colors, bg_colors)
+    for key, value in {
         Color.BGGreen: 'bg:#00ff00',
         Color.Bold: 'bold',
         Color.Bold.BGGreen: 'bold bg:#00ff00',
@@ -46,20 +60,23 @@ def test_color_tokens():
         Color.Faint.BGGreen: 'bg:#00ff00',
         Color.Faint.Red: '#ff0000',
         Color.Faint.Red.BGGreen: '#ff0000 bg:#00ff00',
-    }
+    }.items():
+        assert ret[key] == value
 
 
-def test_color_tokens_256color():
+def test_color_tokens_256color(default_color_tokens):
     fg_colors = {'Red': '#ff0000'}
     bg_colors = {'Green': '#00ff00'}
-
-    expected = dict(
-        itertools.chain.from_iterable(
-            (
-                (getattr(C, f'C{i}'), value),
-                (getattr(C, f'BGC{i}'), f'bg:{value}'),
-            )
-            for i, value in main._256_colors.items()
+    expected = dict(default_color_tokens)
+    expected.update(
+        dict(
+            itertools.chain.from_iterable(
+                (
+                    (getattr(C, f'C{i}'), value),
+                    (getattr(C, f'BGC{i}'), f'bg:{value}'),
+                )
+                for i, value in main._256_colors.items()
+            ),
         ),
     )
     expected.update({


### PR DESCRIPTION
I had to copy and paste the whole set of default color in my code to have `pygments-ansi-color` work as expected. See: https://github.com/kdeldycke/click-extra/blob/115d6a879accf66a4ff71f81cf5693373d79aa3a/click_extra/pygments.py#L55-L72

To simplify even more its use and make it convenient to tweak the default theme, I propose to use it by default and make it a constant.