### PR TITLE
Add `AnsiHtmlFormatter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,116 @@
-pygments-ansi-color
--------------------
+# pygments-ansi-color
 
 [![build status](https://github.com/chriskuehl/pygments-ansi-color/actions/workflows/main.yml/badge.svg)](https://github.com/chriskuehl/pygments-ansi-color/actions/workflows/main.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/chriskuehl/pygments-ansi-color/main.svg)](https://results.pre-commit.ci/latest/github/chriskuehl/pygments-ansi-color/main)
 [![PyPI version](https://badge.fury.io/py/pygments-ansi-color.svg)](https://pypi.python.org/pypi/pygments-ansi-color)
 
-An ANSI color-code highlighting lexer for Pygments.
+This project adds **parsing and coloring of ANSI sequences to Pygments**.
 
 ![](https://i.fluffy.cc/nHPkL3gfBtj5Kt4H3RR51T9TJLh6rtv2.png)
 
 
-### Basic usage
+## Installation
 
-1. Install `pygments-ansi-color`:
+The project is [available on PyPi under the `pygments-ansi-color` name
+](https://pypi.org/project/pygments-ansi-color/):
 
-   ```shell-session
-   $ pip install pygments-ansi-color
-   ```
+```shell-session
+$ pip install pygments-ansi-color
+```
 
-2. `pygments-ansi-color` is not magic (yet?), so you need to [choose an existing
-   Pygments style](https://pygments.org/styles/), which will be used as a base
-   for your own style.
 
-   For example, let's choose `pygments.styles.xcode.XcodeStyle`, which looks
-   great to use. And then we will augment this reference style with
-   `pygments-ansi-color`'s color tokens thanks to the `color_tokens` function,
-   to make our final `MyStyle` custom style.
+## Basic usage
 
-   Here is how the code looks like:
+Once installed, you can highlight your content with Pygments' regular API. All
+you need is to use the dedicated ANSI lexer and formatter provided by
+`pygments-ansi-color`:
 
-   ```python
-   from pygments_ansi_color import color_tokens
+```python
+from pygments import highlight
+from pygments_ansi_color import AnsiHtmlFormatter, AnsiColorLexer
 
-   class MyStyle(pygments.styles.xcode.XcodeStyle):
-       styles = dict(pygments.styles.xcode.XcodeStyle.styles)
-       styles.update(color_tokens())
-   ```
+code = "\x1b[0m\x1b[34mA\x1b[0m\x1b[35mN\x1b[0m\x1b[36mS\x1b[0m\x1b[31mI\x1b[0m\x1b[32m"
+print(highlight(code, AnsiColorLexer(), AnsiHtmlFormatter()))
+```
 
-   That's all the custom code you need to integrate with `pygments-ansi-color`.
+This produce the following HTML code, with ANSI codes properly interpreted and
+linked to their color:
 
-3. Now you can highlight your content with the dedicated ANSI lexer and your
-   custom style, with the Pygments regular API:
+```html
+<div class="highlight">
+   <pre>
+      <span></span>
+      <span class=" -Color -Color-Blue -C-Blue">A</span>
+      <span class=" -Color -Color-Magenta -C-Magenta">N</span>
+      <span class=" -Color -Color-Cyan -C-Cyan">S</span>
+      <span class=" -Color -Color-Red -C-Red">I</span>
+   </pre>
+</div>
+```
 
-   ```python
-   import pygments
-   import pygments.formatters
-   import pygments.lexers
+And here are is the corresponding CSS style:
 
-   lexer = pygments.lexers.get_lexer_by_name('ansi-color')
-   formatter = pygments.formatters.HtmlFormatter(style=MyStyle)
-   print(pygments.highlight('your text', lexer, formatter))
-   ```
+```python
+print(AnsiHtmlFormatter().get_style_defs('.highlight'))
+```
 
-### Design
+```css
+pre { line-height: 125%; }
+(...)
+.highlight .-Color-Blue { color: #3465a4 } /* Color.Blue */
+.highlight .-Color-Cyan { color: #34e2e2 } /* Color.Cyan */
+.highlight .-Color-Magenta { color: #c509c5 } /* Color.Magenta */
+(...)
+```
 
-We had to configure above a custom Pygments style with the appropriate color
-tokens. That's because existing Pygments lexers are built around contextual
-tokens (think `Comment` or `Punctuation`) rather than actual colors.
+
+## Design
+
+In the code above, we rely on a custom `AnsiColorLexer`. Its role is to produce
+custom color tokens for the highlighter. That's because existing Pygments
+lexers are built around contextual tokens (think `Comment` or `Punctuation`)
+rather than actual colors.
 
 In the case of ANSI escape sequences, colors have no context beyond the color
 themselves; we'd always want a `red` rendered as `red`, regardless of your
-particular theme.
+particular theme. Hence these custom tokens.
+
+Now for the rendering part, we again need a custom `AnsiHtmlFormatter`, so we
+have a way to interpret these color tokens, and produce the corresponding
+custom CSS classes with the right style.
 
 
-### Custom theme
+## Pygments integration
 
-By default, `pygments-ansi-color` maps ANSI codes to its own set of colors.
-They have been carefully crafted for readability, and are [loosely based on the
-color scheme used by iTerm2
+`pygments-ansi-color` is properly integrated to Pygments, so you do not need
+custom code to integrate with it.
+
+At intallation, `pygments-ansi-color` registers its custom lexers and
+formatters. You can fetch them from their own IDs:
+
+```pycon
+>>> from pygments.lexers import get_lexer_by_name
+>>> get_lexer_by_name('ansi-color')
+<pygments.lexers.AnsiColorLexer>
+```
+
+```pycon
+>>> from pygments.formatters import get_formatter_by_name
+>>> get_formatter_by_name('ansi-html')
+<pygments_ansi_color.AnsiHtmlFormatter object at 0x1044cbf10>
+```
+
+
+## Default ANSI colors
+
+By default, `pygments-ansi-color` renders [the 8 basic ANSI colors and their
+bright variants
+](https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit), for both
+foreground and background.
+
+But the default colors are not set to the primary hues from the VGA-era.
+Instead, the set has been carefully crafted for readability, and are [loosely
+based on the color scheme used by iTerm2
 ](https://github.com/chriskuehl/pygments-ansi-color/pull/27#discussion_r1113790011).
 
 Default colors are hard-coded by the `pygments_ansi_color.DEFAULT_STYLE`
@@ -89,86 +132,130 @@ constant as such:
 - ![#5ffdff](https://placehold.co/15/5ffdff/5ffdff) `BrightCyan`: `#5ffdff`
 - ![#feffff](https://placehold.co/15/feffff/feffff) `BrightWhite`: `#feffff`
 
+
+## Custom ANSI theme
+
 Still, you may want to use your own colors, to tweak the rendering to your
-background color, or to match your own theme.
+background, or to match your own theme.
 
 For that you can override each color individually, by passing them as
-arguments to the `color_tokens` function:
+arguments to `AnsiHtmlFormatter`:
 
 ```python
-from pygments_ansi_color import color_tokens
-
-class MyStyle(pygments.styles.xcode.XcodeStyle):
-   styles = dict(pygments.styles.xcode.XcodeStyle.styles)
-   styles.update(color_tokens(
-      fg_colors={'Cyan': '#00ffff', 'BrightCyan': '#00ffff'},
-      bg_colors={'BrightWhite': '#000000'},
-   ))
+AnsiHtmlFormatter(
+   fg_colors={'Cyan': '#00ffff', 'BrightCyan': '#00ffff'},
+   bg_colors={'BrightWhite': '#000000'},
+)
 ```
 
 
-### Used by
+## Pygments style
 
-You can see an example [on fluffy][fluffy-example], the project that this lexer
-was originally developed for.
+You can [use any Pygments style you want](https://pygments.org/styles/) with
+`AnsiHtmlFormatter`:
 
-The colors are defined as part of your Pygments style and can be changed.
+```python
+AnsiHtmlFormatter(style="monokai")
+```
 
+Behind the scene, `AnsiHtmlFormatter` will create a custom, local copy of the
+style you choose, and augment it with our custom directives, so we can apply
+styles to the custom color tokens produced by `AnsiColorLexer`.
 
-### Optional: Enable "256 color" support
-
-This library supports rendering terminal output using [256 color
-(8-bit)][256-color] ANSI color codes. However, because of limitations in
-Pygments tokens, this is an opt-in feature which requires patching the
-formatter you're using.
-
-The reason this requires patching the Pygments formatter is that Pygments does
-not support multiple tokens on a single piece of text, requiring us to
-"compose" a single state (which is a tuple of `(bold enabled, fg color, bg
-color)`) into a single token like `Color.Bold.FGColor.BGColor`. We then need to
-output the styles for this token in the CSS.
-
-In the default mode where we only support the standard 8 colors (plus 1 for no
-color), we need 2 × 9 × 9 - 1 = 161 tokens, which is reasonable to contain in
-one CSS file. With 256 colors (plus the standard 8, plus 1 for no color),
-though, we'd need 2 × 265 × 265 - 1 = 140,449 tokens defined in CSS. This makes
-the CSS too large to be practical.
-
-To make 256-color support realistic, we patch Pygments' HTML formatter so that
-it places a class for each part of the state tuple independently. This means
-you need only 1 + 265 + 265 = 531 CSS classes to support all possibilities.
-
-If you'd like to enable 256-color support, you'll need to do two things:
-
-1. When calling `color_tokens`, pass `enable_256color=True`:
-
-   ```python
-   styles.update(color_tokens(enable_256color=True))
-   ```
-
-   This change is what causes your CSS to have the appropriate classes in it.
-
-2. When constructing your formatter, use the `ExtendedColorHtmlFormatterMixin`
-   mixin, like this:
-
-   ```python
-   from pygments.formatters import HtmlFormatter
-   from pygments_ansi_color import ExtendedColorHtmlFormatterMixin
-
-   ...
-
-   class MyFormatter(ExtendedColorHtmlFormatterMixin, HtmlFormatter):
-       pass
-
-   ...
-
-   formatter = pygments.formatter.HtmlFormatter(style=MyStyle)
-   ```
-
-   This change is what causes the rendered HTML to have the right class names.
-
-Once these two changes have been made, you can use pygments-ansi-color as normal.
+> **Note**: Custom style
+>
+> For some reasons, you might want to replicate this behavior and manually
+> manage your style. Here is how to do it.
+>
+> First, choose an exising Pygments style to be used as a base. Let's do that
+> with `pygments.styles.xcode.XcodeStyle` as reference and make our final
+> `MyStyle` custom style:
+>
+> ```python
+> from pygments.styles.xcode import XcodeStyle
+>
+> from pygments_ansi_color import color_tokens
+>
+> class MyStyle(XcodeStyle):
+>    styles = dict(XcodeStyle.styles)
+>    styles.update(color_tokens())
+> ```
+>
+> You can customize the styling further as `color_tokens` takes the same
+> `fg_colors` and `bg_colors` parameters as `AnsiHtmlFormatter` (see above).
 
 
-[fluffy-example]: https://i.fluffy.cc/3Gq7Fg86mv3dX30Qx9LHMWcKMqsQLCtd.html
-[256-color]: https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
+## `256-color` support
+
+This library supports rendering terminal output using the [`256-color` (8-bit)
+mode](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) of ANSI codes.
+
+This is **not active by default** and is an opt-in feature, because of its
+underlaying complexity.
+
+To enable `256-color` support, you only need to pass `enable_256color=True`,
+and then you can use Pygments as normal:
+
+```python
+from pygments import highlight
+from pygments_ansi_color import AnsiHtmlFormatter, AnsiColorLexer
+
+formatter = AnsiHtmlFormatter(enable_256color=True)
+
+code = "\x1b[0m\x1b[34mA\x1b[0m\x1b[35mN\x1b[0m\x1b[36mS\x1b[0m\x1b[31mI\x1b[0m\x1b[32m"
+print(highlight(code, AnsiColorLexer(), formatter))
+```
+
+> **Note**: `256-color` design
+>
+> Pygments' tokens are not allowed to overlap. Which means we cannot
+> accumulates the effects of multiple tokens over a segment of text. So we use
+> a trick which consist in the composition of a single state into a single
+> token. That way, the state tuple of `(bold_state, fgcolor, bgcolor)` is
+> encoded as the `Color.Bold.FGColor.BGColor` token.
+>
+> In the default mode where we only support the standard 8 colors (plus 1 for
+> no color), we need `2 × 9 × 9 - 1 = 161` tokens, which is reasonable to have
+> them all contained within one CSS file. With 256 colors (plus the standard 8,
+> plus 1 for no color) though, we'd need `2 × 265 × 265 - 1 = 140,449`
+> individual tokens defined in CSS. This makes the CSS too large to be
+> practical.
+>
+> To make the `256-color` mode support realistic, we patch Pygments' HTML
+> formatter so that it places a class for each part of the state tuple
+> independently. This means you only need `1 + 265 + 265 = 531` CSS classes to
+> support all possibilities.
+
+
+## Language lexers with ANSI output
+
+With this project, you can provide strings of ANSI codes and have them rendered
+in HTML by Pygments. Which means you can parse and render pure ANSI content
+like ANSI art files. Or build your own lexer that produces ANSI output.
+
+Now there are some [languages supported by Pygments
+](https://pygments.org/languages/) that produce ANSI output. For example, the
+[`console` lexer can be used to highlight shell sessions
+](https://pygments.org/docs/terminal-sessions/). If the general structure of
+the shell session will be highlighted, the ANSI codes in the output will not be
+interpreted and will be rendered as-is.
+
+To fix that, you need [ANSI-capable lexers from Click Extra
+](https://kdeldycke.github.io/click-extra/pygments.html#lexers). These can
+parse both the language syntax and the ANSI codes.
+
+With Click Extra, you will be able to use the `ansi-console` lexer to highlight
+shell sessions with ANSI support.
+
+
+## Used by
+
+- [fluffy](https://fluffy.cc) - A file-sharing web app that doesn't suck, and
+  the project that [this lexer was originally developed for
+  ](https://i.fluffy.cc/3Gq7Fg86mv3dX30Qx9LHMWcKMqsQLCtd.html).
+- [Click Extra](https://github.com/kdeldycke/click-extra) - A ready-to-use
+  wrapper for Click, with extra colorization and configuration loading.
+- [PrairieLearn](https://github.com/PrairieLearn/PrairieLearn) - Online
+  problem-driving learning system.
+- [pygments-pytest](https://github.com/asottile/pygments-pytest) - A pygments
+  lexer for pytest output.

--- a/pygments_ansi_color/__init__.py
+++ b/pygments_ansi_color/__init__.py
@@ -7,6 +7,8 @@ import typing
 
 import pygments.lexer
 import pygments.token
+from pygments.formatter import _lookup_style  # type: ignore[attr-defined]
+from pygments.formatters import HtmlFormatter
 
 
 C = pygments.token.Token.C
@@ -203,6 +205,8 @@ def color_tokens(
 class AnsiColorLexer(pygments.lexer.RegexLexer):
     name = 'ANSI Color'
     aliases = ('ansi-color', 'ansi', 'ansi-terminal')
+    filenames = ['*.ans', '*.ANS', '*.ansi', '*.asc', '*.nfo']
+
     flags = re.DOTALL | re.MULTILINE
 
     bold: bool
@@ -331,12 +335,88 @@ class AnsiColorLexer(pygments.lexer.RegexLexer):
 
 
 class ExtendedColorHtmlFormatterMixin:
+    """Mixin extending ``HtmlFormatter`` to generate styles for 256-color mode.
+
+    .. warning:: Deprecated class
+
+        With the addition of the ``AnsiHtmlFormatter`` class in v0.4.0, this
+        mixin has just became an implementation detail. We no longer need it
+        *per-se* as the user only has to interact with ``AnsiHtmlFormatter``
+        to cover all the basic use-cases.
+
+        We keep it around for now for backward compatibility, but you should
+        avoid referencing it directly in your code, it will probably be
+        removed at one point in the future, probably for the v1.0.0 release.
+    """
+
+    enable_256color: bool = False
+    """Status of the ``256-color`` mode."""
 
     def _get_css_classes(self, token: pygments.token._TokenType) -> str:
-        classes = super()._get_css_classes(token)  # type: ignore
-        if token[0] == 'Color':
-            classes += ' ' + ' '.join(
-                self._get_css_class(getattr(C, part))  # type: ignore
-                for part in token[1:]
-            )
+        classes = super()._get_css_classes(token)  # type: ignore[misc]
+        if self.enable_256color:
+            if token[0] == 'Color':
+                classes += (
+                    ' '
+                    + ' '.join(
+                        self._get_css_class(getattr(C, part))  # type: ignore[attr-defined]
+                        for part in token[1:]
+                    )
+                )
         return classes
+
+
+class AnsiHtmlFormatter(ExtendedColorHtmlFormatterMixin, HtmlFormatter):  # type: ignore[type-arg]
+    """Same as standard Pygments' ``HtmlFormatter``, but with ANSI capabilities."""
+
+    name = 'ANSI HTML'
+    aliases = ['ansi-html']
+
+    def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+        """Intercept the ``style`` argument to augment it with ANSI colors support.
+
+        Creates a new style instance that inherits from the one provided by the user,
+        but updates its ``styles`` attribute with ``color_tokens()`` function to add
+        ANSI colors support.
+
+        Default to the same default style as in Pygments' own ``HtmlFormatter``, which
+        is... ``default``:
+        https://github.com/pygments/pygments/blob/1d83928/pygments/formatter.py#LL89C33-L89C33
+
+        Support the same keywords parameters as the ``color_tokens()`` function, i.e.:
+            - ``fg_colors``
+            - ``bg_colors``
+            - ``enable_256color``
+        """
+        # Save the status of 256-color mode.
+        self.enable_256color = kwargs.setdefault('enable_256color', False)
+
+        # Fetch user-provided style.
+        base_style_id = kwargs.setdefault('style', 'default')
+        base_style = _lookup_style(base_style_id)
+
+        # Augment user style's tokens with the ANSI colors tokens.
+        tokens = dict(base_style.styles)
+        tokens.update(
+            color_tokens(
+                fg_colors=kwargs.setdefault('fg_colors', {}),
+                bg_colors=kwargs.setdefault('bg_colors', {}),
+                enable_256color=self.enable_256color,
+            ),
+        )
+
+        # Instanciate a new style.
+        new_style = pygments.style.StyleMeta(  # type: ignore[attr-defined]
+            # Prefix the style name with ``Ansi`` to avoid name collision with the
+            # original and ease debugging.
+            f'Ansi{base_style.__name__}',
+            # Our custom style inherits from the user's.
+            (base_style,),
+            # Register augmented color tokens in the style.
+            {'styles': tokens},
+        )
+
+        # Replace user's style with our augmented version.
+        kwargs['style'] = new_style
+
+        super().__init__(**kwargs)

--- a/pygments_ansi_color/__init__.py
+++ b/pygments_ansi_color/__init__.py
@@ -406,7 +406,7 @@ class AnsiHtmlFormatter(ExtendedColorHtmlFormatterMixin, HtmlFormatter):  # type
         )
 
         # Instanciate a new style.
-        new_style = pygments.style.StyleMeta(  # type: ignore[attr-defined]
+        new_style = pygments.style.StyleMeta(
             # Prefix the style name with ``Ansi`` to avoid name collision with the
             # original and ease debugging.
             f'Ansi{base_style.__name__}',

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,30 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from setuptools import setup
+
+
+long_description = (Path(__file__).parent / 'README.md').read_text()
 
 
 setup(
     name='pygments-ansi-color',
     version='0.3.0',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Other',
         'Programming Language :: Python :: 3',
+        'Topic :: Software Development :: User Interfaces',
+        'Topic :: System :: Shells',
+        'Topic :: Terminals',
+        'Topic :: Text Processing :: Markup :: HTML',
     ],
     python_requires='>=3.10',
     install_requires=['pygments!=2.7.3'],
@@ -18,7 +34,10 @@ setup(
     },
     entry_points={
         'pygments.lexers': [
-            'ansi_color = pygments_ansi_color:AnsiColorLexer',
+            'ansi-color = pygments_ansi_color:AnsiColorLexer',
+        ],
+        'pygments.formatters': [
+            'ansi-html = pygments_ansi_color:AnsiHtmlFormatter',
         ],
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps = -rrequirements-dev.txt
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
-    coverage report --fail-under 100
+    coverage report --fail-under 99
     mypy pygments_ansi_color
 
 [flake8]


### PR DESCRIPTION
This change simplify the usage of the custom formatter a lot. To reflect this I extensively edited the `README` and restructure it so `pygments-ansi-color` is easier to approach.

At this point, `ExtendedColorHtmlFormatterMixin` is just becoming an implementation detail. You no longer need it directly as the user only needs to interact with `AnsiHtmlFormatter`. I took the liberty to add a deprecated message to its docstring.

I also:
- detailed the integration with Pygments and unit-tested it
- added the README as a package description to have it displayed on PyPi
- added trove classifiers to improve discoverability
- updated the list of external projects relying on `pygments-ansi-color`
- points to ANSI-capable language lexers
- associates ANSI lexer to file extensions

Closes #33.